### PR TITLE
Fix axis comments in 2_locating_array_values.ipynb

### DIFF
--- a/mod2_numpy_fundamentals/2_locating_array_values.ipynb
+++ b/mod2_numpy_fundamentals/2_locating_array_values.ipynb
@@ -162,18 +162,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The smallest elements in each row: [12 25  1]\n",
-      "The smallest elements in each column: [12  1 46]\n"
+      "The smallest elements in each row: [12  1 46]\n",
+      "The smallest elements in each column: [12 25  1]\n"
      ]
     }
    ],
    "source": [
     "# Note: \n",
-    "# - compare elements in each row --> axis = 0 \n",
-    "# - compare elements in each column --> axis = 1\n",
+    "# - compare elements in each column --> axis = 0\n",
+    "# - compare elements in each row --> axis = 1\n",
+    "# (This is a bit contrary to our usual way of thinking \"rows and columns\")\n"
     "\n",
-    "print(f\"The smallest elements in each row: {np.min(my_array, axis = 0)}\")\n",
-    "print(f\"The smallest elements in each column: {np.min(my_array, axis = 1)}\")"
+    "print(f\"The smallest elements in each row: {np.min(my_array, axis = 1)}\")\n",
+    "print(f\"The smallest elements in each column: {np.min(my_array, axis = 0)}\")"
    ]
   },
   {


### PR DESCRIPTION
The notebook taught incorrectly about the axis argument. Fixed it. 